### PR TITLE
Use a generic 'mapping type' for metric data

### DIFF
--- a/common.py
+++ b/common.py
@@ -69,10 +69,9 @@ class ESWrite(object):
     def write(self):
         """This function writes the data to elastic search"""
         self.dictionary = json.dumps(self.dictionary)
-        requests.post('%s/%s-%s/metric_data/' %
-                      ('http://elasticsearch2.gridpp.rl.ac.uk:9200',
-                       'logstash-gridtools-metrics',
-                       date),
+        requests.post(("http://elasticsearch2.gridpp.rl.ac.uk:9200/"
+                       "logstash-gridtools-metrics-%s/"
+                       "metric_data/") % date,
                       data=self.dictionary)
 
 def es_check():

--- a/common.py
+++ b/common.py
@@ -69,9 +69,9 @@ class ESWrite(object):
     def write(self):
         """This function writes the data to elastic search"""
         self.dictionary = json.dumps(self.dictionary)
-        requests.post(("http://elasticsearch2.gridpp.rl.ac.uk:9200/"
-                       "logstash-gridtools-metrics-%s/"
-                       "metric_data/") % date,
+        requests.post("http://elasticsearch2.gridpp.rl.ac.uk:9200/"
+                      "logstash-gridtools-metrics-%s/"
+                      "metric_data/" % date,
                       data=self.dictionary)
 
 def es_check():

--- a/common.py
+++ b/common.py
@@ -69,9 +69,11 @@ class ESWrite(object):
     def write(self):
         """This function writes the data to elastic search"""
         self.dictionary = json.dumps(self.dictionary)
-        requests.post('http://elasticsearch2.gridpp.rl.ac.uk:9200/logstash' +
-                       '-gridtools-metrics-'
-                       + date + '/apel/', data=self.dictionary)
+        requests.post('%s/%s-%s/metric_data/' %
+                      ('http://elasticsearch2.gridpp.rl.ac.uk:9200',
+                       'logstash-gridtools-metrics',
+                       date),
+                      data=self.dictionary)
 
 def es_check():
     '''This function checks to see if elastic search is up '''


### PR DESCRIPTION
- as all metric data (i.e. APEL and GOCDB) was getting the mapping type 'apel'.
- I did consider splitting the APEL and GOCDB metrics into separate mapping types, but as in future ElasticSearch versions mapping types are being removed this didn't seem sensible. 
- also replace string string concatenation with string formatting