### PR TITLE
Store metric data gathered today in an index dated today

### DIFF
--- a/common.py
+++ b/common.py
@@ -7,9 +7,6 @@ import json
 import requests
 from datetime import datetime, timedelta
 
-date = datetime.strftime(datetime.now() - timedelta(1), '%Y.%m.%d')
-
-
 logger = logging.getLogger(__name__)
 
 class GetData(object):
@@ -69,6 +66,9 @@ class ESWrite(object):
     def write(self):
         """This function writes the data to elastic search"""
         self.dictionary = json.dumps(self.dictionary)
+
+        date = datetime.strftime(datetime.now(), '%Y.%m.%d')
+
         requests.post("http://elasticsearch2.gridpp.rl.ac.uk:9200/"
                       "logstash-gridtools-metrics-%s/"
                       "metric_data/" % date,


### PR DESCRIPTION
- A barrier to graphing the metric data in kibana is that the scripts currently put data into yesterday's index.
- This felt right at the time as the data are metrics for the entirety of yesterday.
- But now I'd rather have fancy graphs.
- also moves declaration of `date` to the `write()` method as that's where its used.