### PR TITLE
Migrate GOCDB metric gathering to make use of ElasticStack 6.X

### DIFF
--- a/common.py
+++ b/common.py
@@ -6,6 +6,7 @@ import logging
 import json
 import requests
 from datetime import datetime, timedelta
+from elasticsearch import Elasticsearch
 
 logger = logging.getLogger(__name__)
 
@@ -62,17 +63,44 @@ class ESWrite(object):
     """This class writes to elastic search"""
     def __init__(self, dictionary):
         self.dictionary = dictionary
+        self.elastic = Elasticsearch(
+            [
+                {
+                    'host': 'elasticsearch1.gridpp.rl.ac.uk',
+                    'port': 9200,
+                },
+                {
+                    'host': 'elasticsearch5.gridpp.rl.ac.uk',
+                    'port': 9200,
+                },
+                {
+                    'host': 'elasticsearch6.gridpp.rl.ac.uk',
+                    'port': 9200,
+                },
+                {
+                    'host': 'elasticsearch7.gridpp.rl.ac.uk',
+                    'port': 9200,
+                },
+                {
+                    'host': 'elasticsearch8.gridpp.rl.ac.uk',
+                    'port': 9200,
+                },
+            ],
+            use_ssl=True,
+            verify_certs=False,
+        )
 
     def write(self):
         """This function writes the data to elastic search"""
-        self.dictionary = json.dumps(self.dictionary)
+        data = json.dumps(self.dictionary)
 
         date = datetime.strftime(datetime.now(), '%Y.%m.%d')
 
-        requests.post("http://elasticsearch2.gridpp.rl.ac.uk:9200/"
-                      "logstash-gridtools-metrics-%s/"
-                      "metric_data/" % date,
-                      data=self.dictionary)
+        self.elastic.index(
+            index="logstash-gridtools-metrics-%s" % date,
+            doc_type='doc',
+            body=data,
+        )
 
 def es_check():
     '''This function checks to see if elastic search is up '''

--- a/common.py
+++ b/common.py
@@ -101,12 +101,3 @@ class ESWrite(object):
             doc_type='doc',
             body=data,
         )
-
-def es_check():
-    '''This function checks to see if elastic search is up '''
-    code = requests.get("http://elasticsearch2.gridpp.rl.ac.uk" +
-                        "/logstash-gridtools-metrics-2018.07.07/gocdb/_search").status_code
-    if code == 200:
-        return True
-    else:
-        return False

--- a/metrics_apel.py
+++ b/metrics_apel.py
@@ -4,7 +4,7 @@ import xml.dom.minidom
 from datetime import datetime, timedelta
 from elasticsearch import Elasticsearch
 import logging
-from common import GetData, ModLogger, ESWrite, es_check
+from common import GetData, ModLogger, ESWrite
 from optparse import OptionParser
 
 
@@ -200,7 +200,6 @@ def main(options):
 
     logger.info('Service has started')
 
-    es_up = es_check()
     # List of service endpoint types to record metrics about
     endpoint_types = ['gLite-APEL', 'APEL', 'eu.egi.cloud.accounting',
                       'eu.egi.storage.accounting']
@@ -248,13 +247,10 @@ def main(options):
         logger.error("Error connecting to GOCDB, "
                      "some metrics may not be fetched.")
 
-    if es_up == True:
-        for query_type in query_type_list:
-            apel_metrics_dict['Number of records loaded for ' + query_type
-                              + ' accounting'] = get_records(query_type)
-    else:
-        print("Elastic Search is currently down." +
-              " No data could be read or written!")
+    for query_type in query_type_list:
+        apel_metrics_dict['Number of records loaded for ' + query_type
+                          + ' accounting'] = get_records(query_type)
+
 
     if options.write == "True":
         ESWrite(apel_metrics_dict).write()

--- a/metrics_apel.py
+++ b/metrics_apel.py
@@ -207,7 +207,10 @@ def main(options):
     query_type_list = ['storage', 'cloud', 'grid']
 
     # master dictionary
-    apel_metrics_dict = {}
+    apel_metrics_dict = {
+        'type': 'apel_metric',
+        '@timestamp': datetime.now().isoformat()
+    }
 
     all_countries = set()
     try:

--- a/metrics_apel.py
+++ b/metrics_apel.py
@@ -8,7 +8,6 @@ from common import GetData, ModLogger, ESWrite
 from optparse import OptionParser
 
 
-ELASTIC_SEARCH_HOST = "elasticsearch2.gridpp.rl.ac.uk"
 logger = logging.getLogger('APEL logger')
 country_list = []
 
@@ -161,7 +160,6 @@ def get_records(query_type):
     This function also makes use of the Elasticsearch module.
     """
     date = datetime.strftime(datetime.now() - timedelta(1), '%Y.%m.%d')
-    elastic = Elasticsearch(ELASTIC_SEARCH_HOST)
     params_dict = {
         "query": {
             "bool": {
@@ -177,7 +175,7 @@ def get_records(query_type):
         }
     }
 
-    result = elastic.search(index="logstash-" + date, body=params_dict)
+    result = ESWrite({}).elastic.search(index="logstash-" + date, body=params_dict)
 
     total = result["aggregations"]["total_number_loaded"]["value"]
     return total

--- a/metrics_gocdb.py
+++ b/metrics_gocdb.py
@@ -192,10 +192,10 @@ def __main__(options):
         response_xml = xml.dom.minidom.parseString(response_text)
 
         user_number = _parse_get_user_xml(response_xml)
-        gocdb_metrics_dict['Number of registerd GOCDB users'] = user_number
+        gocdb_metrics_dict['Number of registered GOCDB users'] = user_number
 
         users_with_role_number = _parse_get_user_xml_roles(response_xml)
-        gocdb_metrics_dict['Number of registerd GOCDB users with a role'] = users_with_role_number
+        gocdb_metrics_dict['Number of registered GOCDB users with a role'] = users_with_role_number
 
     except requests.exceptions.ConnectionError as error:
         print(error)

--- a/metrics_gocdb.py
+++ b/metrics_gocdb.py
@@ -156,7 +156,10 @@ def __main__(options):
     ModLogger('GOCDB.log').logger_mod()
     logger.info('service has started')
 
-    gocdb_metrics_dict = {}
+    gocdb_metrics_dict = {
+        'type': 'gocdb_metric',
+        '@timestamp': datetime.now().isoformat()
+    }
 
     try:
         # Get the number of registered service providers (aka sites)

--- a/metrics_gocdb.py
+++ b/metrics_gocdb.py
@@ -3,7 +3,7 @@ import requests
 import xml.dom.minidom
 from datetime import datetime, timedelta
 import logging
-from common import ESWrite, GetData, ModLogger, es_check
+from common import ESWrite, GetData, ModLogger
 from optparse import OptionParser
 
 
@@ -150,7 +150,6 @@ def __main__(options):
     session = requests.Session()
     session.cert = (options.certificate, options.key)
 
-    es_up = es_check()
     logger = logging.getLogger('GOCDB logger')
     logger.addHandler(logging.NullHandler())
     ModLogger('GOCDB.log').logger_mod()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Elasticsearch 6.x
+elasticsearch>=6.0.0,<7.0.0


### PR DESCRIPTION
This PR:

- Removes `get_queries` and `get_unique_ips_over_28_days` from `metrics_gocdb.py` as we no longer know exactly what index the data goes into and such queries can now be achieved more easily by ElasticStack 6.X.
- Uses the elasticsearch-py library to write to cluster because that feels better than worrying about constructing a suitable POST/PUT request to a magical url.
-  Removes `es_check` function from `common.py` (and references to it elsewhere) because our new cluster is much more reliable than the old and is always<sup>TM</sup> up.
- Fix typo's in GOCDB's metric dictionary keys.
-  Add type and @timestamp to metric data dictionary (also applied to `metrics_apel.py`). `type` allows us to differentiate data in the same index easily, `@timestamp` allows us to graph data in Kibana

I also changed the elasticsearch host `metrics_apel.py` is reading from to a host in the new cluster because it didn't feel right leaving this single legacy reference. 
